### PR TITLE
cachyos.cfg: Enable browser.tabs.unloadOnLowMemory by default

### DIFF
--- a/cachyos.cfg
+++ b/cachyos.cfg
@@ -58,6 +58,7 @@ defaultPref("browser.privatebrowsing.forceMediaMemoryCache", true);
 defaultPref("media.memory_cache_max_size", 65536);
 defaultPref("browser.shell.shortcutFavicons", false); // disable favicons in profile folder
 defaultPref("browser.helperApps.deleteTempFileOnExit", true); // delete temporary files opened with external apps
+defaultPref("browser.tabs.unloadOnLowMemory", true); // Unload unused tabs
 
 /** [SECTION] HISTORY AND SESSION RESTORE
  * since we hide the UI for modes other than custom we want to reset it for


### PR DESCRIPTION
It saves A LOT of memory, and I see no reason to keep it turned off.