### PR TITLE
Better defaults to make the browser more usable 

### DIFF
--- a/cachyos.cfg
+++ b/cachyos.cfg
@@ -139,7 +139,8 @@ defaultPref("browser.urlbar.speculativeConnect.enabled", false);
  * librewolf should stick to RFP for fingerprinting. we should not set prefs that interfere with it
  * and disabling API for no good reason will be counter productive, so it should also be avoided.
  */
-defaultPref("privacy.resistFingerprinting", true);
+// resistFingerprinting breaks too many websites and our users were complaining a lot, therefore is better to leave it disabled and let the user decide whether to enable it or not.
+defaultPref("privacy.resistFingerprinting", false);
 // rfp related settings
 defaultPref("privacy.resistFingerprinting.block_mozAddonManager", true); // prevents rfp from breaking AMO
 defaultPref("browser.display.use_system_colors", false); // default, except Win
@@ -225,11 +226,12 @@ defaultPref("pdfjs.enableScripting", false); // disable js scripting in the buil
 /** [SECTION] LOCATION
  * replace google with mozilla as the default geolocation provide and prevent use of OS location services
  */
-defaultPref("geo.provider.network.url", "https://location.services.mozilla.com/v1/geolocate?key=%MOZILLA_API_KEY%");
-defaultPref("geo.provider.ms-windows-location", false); // [WINDOWS]
-defaultPref("geo.provider.use_corelocation", false); // [MAC]
-defaultPref("geo.provider.use_gpsd", false); // [LINUX]
-defaultPref("geo.provider.use_geoclue", false); // [LINUX]
+// Geolocation service by Mozilla has been discontinued since 06/12/2024. see https://github.com/mozilla/ichnaea/issues/2065
+//defaultPref("geo.provider.network.url", "https://location.services.mozilla.com/v1/geolocate?key=%MOZILLA_API_KEY%");
+//defaultPref("geo.provider.ms-windows-location", false); // [WINDOWS]
+//defaultPref("geo.provider.use_corelocation", false); // [MAC]
+//defaultPref("geo.provider.use_gpsd", false); // [LINUX]
+//defaultPref("geo.provider.use_geoclue", false); // [LINUX]
 
 /** [SECTION] LANGUAGE
  * show language as en-US for all users, regardless of their OS language and browser language.
@@ -553,7 +555,7 @@ defaultPref("browser.startup.preXulSkeletonUI", false);
 
 /** EXPERIMENTAL ***/
 defaultPref("layout.css.grid-template-masonry-value.enabled", true);
-defaultPref("dom.enable_web_task_scheduling", true);
+defaultPref("dom.enable_web_task_scheduling", false); // This might cause breakage on some websites such as a navigation bar for Google Cloud, see https://github.com/yokoffing/Betterfox/issues/355
 
 /** GFX ***/
 defaultPref("gfx.webrender.all", true);
@@ -561,7 +563,7 @@ defaultPref("gfx.webrender.precache-shaders", true);
 defaultPref("gfx.webrender.compositor", true);
 defaultPref("layers.gpu-process.enabled", true);
 defaultPref("layers.gpu-process.force-enabled", true);
-defaultPref("media.hardware-video-decoding.enabled", true);
+//defaultPref("media.hardware-video-decoding.enabled", true); // Enabled by default since FF136
 defaultPref("gfx.canvas.accelerated", true);
 defaultPref("gfx.canvas.accelerated.cache-items", 4096);
 defaultPref("gfx.canvas.accelerated.cache-size", 512);


### PR DESCRIPTION
Since we are constantly receiving complaints about breakage on websites, graphical glitches and so on, its better to make Cachy Browser slightly less hardened by trading privacy for usability.

The following parameters are now disabled:

`resistFingerprinting `- This is the reason many websites either break or partially stop working.
 Geolocation related changes since Mozilla's service has been discontinued in 2024
`dom.enable_web_task_scheduling` - is known to cause breakage on some websites. For example a navigation bar in Google Cloud, see [https://github.com/yokoffing/Betterfox/issues/355](url)

The following is commented:

`media.hardware-video-decoding.enabled` - Now enabled by default since FF136